### PR TITLE
fix: not matching model types causing error while creating a resource

### DIFF
--- a/src/main/java/io/gravitee/resource/ai_model/configuration/ModelEnum.java
+++ b/src/main/java/io/gravitee/resource/ai_model/configuration/ModelEnum.java
@@ -42,14 +42,14 @@ public enum ModelEnum {
         "config.json"
     ),
     GRAVITEE_LLAMA_PROMPT_GUARD_22M_MODEL(
-        "LLAMA_PROMPT_GUARD_22M_MODEL",
+        "GRAVITEE_LLAMA_PROMPT_GUARD_22M_MODEL",
         "gravitee-io/Llama-Prompt-Guard-2-22M-onnx",
         "model.quant.onnx",
         "tokenizer.json",
         "config.json"
     ),
     GRAVITEE_LLAMA_PROMPT_GUARD_86M_MODEL(
-        "LLAMA_PROMPT_GUARD_86M_MODEL",
+        "GRAVITEE_LLAMA_PROMPT_GUARD_86M_MODEL",
         "gravitee-io/Llama-Prompt-Guard-2-86M-onnx",
         "model.quant.onnx",
         "tokenizer.json",


### PR DESCRIPTION
**Description**

fix: not matching model types causing error while creating a resource



<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-incorrect-enum-fix-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-text-classification/1.0.0-incorrect-enum-fix-SNAPSHOT/gravitee-resource-ai-model-text-classification-1.0.0-incorrect-enum-fix-SNAPSHOT.zip)
  <!-- Version placeholder end -->
