### PR TITLE
fix: remove inference service initialization at resource start up

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <gravitee-node.version>7.8.0</gravitee-node.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-ai-model-api.version>1.0.0</gravitee-resource-ai-model-api.version>
-        <gravitee-inference-service.version>1.1.0</gravitee-inference-service.version>
-
+        <gravitee-inference.version>1.1.2</gravitee-inference.version>
+        <gravitee-inference-service.version>1.1.2</gravitee-inference-service.version>
         <wiremock.version>3.13.0</wiremock.version>
 
         <maven-plugin-properties.version>1.2.1</maven-plugin-properties.version>
@@ -94,17 +94,17 @@
             <artifactId>gravitee-resource-ai-model-api</artifactId>
             <version>${gravitee-resource-ai-model-api.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.gravitee.inference.api</groupId>
+            <artifactId>gravitee-inference-api</artifactId>
+            <version>${gravitee-inference.version}</version>
+        </dependency>
 
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.gravitee.inference.service</groupId>
-            <artifactId>gravitee-inference-service</artifactId>
-            <version>${gravitee-inference-service.version}</version>
         </dependency>
 
         <!-- Vert.x dependencies -->
@@ -116,6 +116,21 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-web-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <!-- SLF4J dependencies -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Jackson dependencies -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -161,6 +176,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.gravitee.inference.service</groupId>
+            <artifactId>gravitee-inference-service</artifactId>
+            <version>${gravitee-inference-service.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/resource/ai_model/TextClassificationAiModelResource.java
+++ b/src/main/java/io/gravitee/resource/ai_model/TextClassificationAiModelResource.java
@@ -15,7 +15,6 @@
  */
 package io.gravitee.resource.ai_model;
 
-import io.gravitee.inference.service.InferenceService;
 import io.gravitee.resource.ai_model.api.AiTextClassificationModelResource;
 import io.gravitee.resource.ai_model.api.ClassifierResults;
 import io.gravitee.resource.ai_model.api.model.PromptInput;
@@ -47,9 +46,9 @@ public class TextClassificationAiModelResource
     private Path modelDirectory;
 
     private ApplicationContext applicationContext;
-    private InferenceServiceClient inferenceServiceClient;
     private HuggingFaceDownloaderService huggingFaceDownloaderService;
     private Vertx vertx;
+    private InferenceServiceClient inferenceServiceClient;
 
     @Override
     protected void doStart() throws Exception {
@@ -61,10 +60,7 @@ public class TextClassificationAiModelResource
         this.modelDirectory = Files.createTempDirectory(modelName.replace("/", "-"));
 
         this.vertx = applicationContext.getBean(Vertx.class);
-
-        var inferenceService = new InferenceService(vertx);
-        this.inferenceServiceClient = new InferenceServiceClient(vertx, inferenceService);
-        inferenceServiceClient.initialize();
+        this.inferenceServiceClient = new InferenceServiceClient(vertx);
 
         var huggingFaceWebClient = HuggingFaceWebClientFactory.createDefaultClient(vertx);
         var vertxHuggingFaceClientRx = new VertxHuggingFaceClientRx(huggingFaceWebClient);

--- a/src/main/java/io/gravitee/resource/ai_model/client/InferenceServiceClient.java
+++ b/src/main/java/io/gravitee/resource/ai_model/client/InferenceServiceClient.java
@@ -30,7 +30,6 @@ import io.gravitee.inference.api.service.InferenceAction;
 import io.gravitee.inference.api.service.InferenceFormat;
 import io.gravitee.inference.api.service.InferenceRequest;
 import io.gravitee.inference.api.service.InferenceType;
-import io.gravitee.inference.service.InferenceService;
 import io.gravitee.resource.ai_model.model.ModelFileType;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.buffer.Buffer;
@@ -44,17 +43,11 @@ import lombok.extern.slf4j.Slf4j;
 public class InferenceServiceClient {
 
     private final Vertx vertx;
-    private final InferenceService inferenceService;
 
     private String modelAddress;
 
-    public InferenceServiceClient(Vertx vertx, InferenceService inferenceService) {
+    public InferenceServiceClient(Vertx vertx) {
         this.vertx = vertx;
-        this.inferenceService = inferenceService;
-    }
-
-    public void initialize() throws Exception {
-        inferenceService.start();
     }
 
     public Single<ClassifierResults> inferModel(String prompt, Map<ModelFileType, String> modelFiles) {

--- a/src/test/java/io/gravitee/resource/ai_model/TestConfiguration.java
+++ b/src/test/java/io/gravitee/resource/ai_model/TestConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.gravitee.resource.ai_model;
 
+import io.gravitee.inference.service.InferenceService;
 import io.gravitee.resource.ai_model.configuration.ModelConfiguration;
 import io.gravitee.resource.ai_model.configuration.ModelEnum;
 import io.gravitee.resource.ai_model.configuration.TextClassificationAiModelConfiguration;
@@ -36,5 +37,10 @@ public class TestConfiguration {
     @Bean
     public TextClassificationAiModelConfiguration configuration() {
         return new TextClassificationAiModelConfiguration(new ModelConfiguration(ModelEnum.MINILMV2_TOXIC_JIGSAW_MODEL));
+    }
+
+    @Bean
+    public InferenceService inferenceService(Vertx vertx) {
+        return new InferenceService(vertx);
     }
 }

--- a/src/test/java/io/gravitee/resource/ai_model/TextClassificationAiModelResourceIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/ai_model/TextClassificationAiModelResourceIntegrationTest.java
@@ -17,6 +17,7 @@ package io.gravitee.resource.ai_model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.gravitee.inference.service.InferenceService;
 import io.gravitee.resource.ai_model.api.ClassifierResults;
 import io.gravitee.resource.ai_model.api.model.PromptInput;
 import java.util.Comparator;
@@ -38,14 +39,19 @@ class TextClassificationAiModelResourceIntegrationTest {
     @Autowired
     TextClassificationAiModelResource resource;
 
+    @Autowired
+    InferenceService inferenceService;
+
     @BeforeEach
     void setUp() throws Exception {
         resource.doStart();
+        inferenceService.start();
     }
 
     @AfterEach
     void tearDown() throws Exception {
         resource.doStop();
+        inferenceService.stop();
     }
 
     @Test

--- a/src/test/java/io/gravitee/resource/ai_model/client/InferenceServiceClientTest.java
+++ b/src/test/java/io/gravitee/resource/ai_model/client/InferenceServiceClientTest.java
@@ -17,18 +17,15 @@ package io.gravitee.resource.ai_model.client;
 
 import static io.gravitee.inference.api.Constants.SERVICE_INFERENCE_MODELS_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.inference.api.classifier.ClassifierResult;
 import io.gravitee.inference.api.classifier.ClassifierResults;
-import io.gravitee.inference.service.InferenceService;
 import io.gravitee.resource.ai_model.model.ModelFileType;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.buffer.Buffer;
@@ -59,15 +56,12 @@ class InferenceServiceClientTest {
     @Mock
     Message<Buffer> inferResponse;
 
-    @Mock
-    InferenceService inferenceService;
-
     @InjectMocks
     InferenceServiceClient client;
 
     @BeforeEach
     void setup() {
-        client = new InferenceServiceClient(vertx, inferenceService);
+        client = new InferenceServiceClient(vertx);
     }
 
     @Test
@@ -171,18 +165,5 @@ class InferenceServiceClientTest {
             .inferModel(prompt, modelFiles)
             .test()
             .assertError(e -> e instanceof RuntimeException && e.getMessage().equals("Model loading failed"));
-    }
-
-    @Test
-    void shouldInitializeService() throws Exception {
-        client.initialize();
-        verify(inferenceService).start();
-    }
-
-    @Test
-    void shouldFailWhenStartThrowsException() throws Exception {
-        doThrow(new RuntimeException("Inference service failed loading")).when(inferenceService).start();
-
-        assertThatThrownBy(() -> client.initialize()).isInstanceOf(RuntimeException.class).hasMessage("Inference service failed loading");
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8987

**Description**

The inference service is no longer created and started by the ai-model-text-classification resource.
APIM will handle this part. 
The dependency for the inference service is left only in the test scope for integration test purposes  

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-remove-inference-service-intialization-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-text-classification/1.0.0-remove-inference-service-intialization-SNAPSHOT/gravitee-resource-ai-model-text-classification-1.0.0-remove-inference-service-intialization-SNAPSHOT.zip)
  <!-- Version placeholder end -->
