### PR TITLE
fix: stop classification model when plugin stops

### DIFF
--- a/src/main/java/io/gravitee/resource/ai_model/TextClassificationAiModelResource.java
+++ b/src/main/java/io/gravitee/resource/ai_model/TextClassificationAiModelResource.java
@@ -35,7 +35,9 @@ import io.reactivex.rxjava3.core.Single;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class TextClassificationAiModelResource
     extends AiTextModelResource<TextClassificationAiModelConfiguration, io.gravitee.inference.api.classifier.ClassifierResults, ClassifierResults> {
 
@@ -55,6 +57,12 @@ public class TextClassificationAiModelResource
     @Override
     protected void doStop() throws Exception {
         super.doStop();
+        inferenceServiceClient
+            .stopModel()
+            .subscribe(
+                address -> log.debug("Model [{}] at address [{}] stopped", modelId, address),
+                throwable -> log.error("Model {} stopped", modelId, throwable)
+            );
     }
 
     private List<ModelFile> getModelFiles() {


### PR DESCRIPTION
**Description**

This PR fixes the model address not being decommissioned when resource is shut down
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-fix-stop-model-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-text-classification/1.0.0-fix-stop-model-SNAPSHOT/gravitee-resource-ai-model-text-classification-1.0.0-fix-stop-model-SNAPSHOT.zip)
  <!-- Version placeholder end -->
