### PR TITLE
chore: validate blocking test on load model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,8 @@
         <gravitee-node.version>7.8.0</gravitee-node.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
         <gravitee-resource-ai-model-api.version>2.0.1</gravitee-resource-ai-model-api.version>
-        <gravitee-inference.version>1.1.2</gravitee-inference.version>
-        <gravitee-inference-service.version>1.1.2</gravitee-inference-service.version>
+        <gravitee-inference-api.version>1.1.2</gravitee-inference-api.version>
+        <gravitee-inference-service.version>1.1.3</gravitee-inference-service.version>
         <gravitee-huggingface-reactive-webclient.version>1.0.0</gravitee-huggingface-reactive-webclient.version>
         <wiremock.version>3.13.0</wiremock.version>
 
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>io.gravitee.inference.api</groupId>
             <artifactId>gravitee-inference-api</artifactId>
-            <version>${gravitee-inference.version}</version>
+            <version>${gravitee-inference-api.version}</version>
         </dependency>
         <dependency>
             <groupId>io.gravitee.huggingface</groupId>

--- a/src/test/java/io/gravitee/resource/ai_model/TestConfiguration.java
+++ b/src/test/java/io/gravitee/resource/ai_model/TestConfiguration.java
@@ -15,10 +15,7 @@
  */
 package io.gravitee.resource.ai_model;
 
-import io.gravitee.huggingface.reactive.webclient.downloader.HuggingFaceDownloader;
 import io.gravitee.inference.service.InferenceService;
-import io.gravitee.resource.ai_model.api.model.ModelFile;
-import io.gravitee.resource.ai_model.api.model.ModelFileType;
 import io.gravitee.resource.ai_model.configuration.ModelConfiguration;
 import io.gravitee.resource.ai_model.configuration.ModelEnum;
 import io.gravitee.resource.ai_model.configuration.TextClassificationAiModelConfiguration;

--- a/src/test/java/io/gravitee/resource/ai_model/TextClassificationAiModelResourceIntegrationTest.java
+++ b/src/test/java/io/gravitee/resource/ai_model/TextClassificationAiModelResourceIntegrationTest.java
@@ -78,7 +78,6 @@ class TextClassificationAiModelResourceIntegrationTest {
         Observable
             .timer(15, TimeUnit.SECONDS)
             .flatMapSingle(i -> resource.invokeModel(new PromptInput("Nobody asked for your bullsh*t response.")))
-            .subscribeOn(RxHelper.blockingScheduler(vertx.getDelegate()))
             .test()
             .awaitDone(20, TimeUnit.SECONDS)
             .assertComplete()

--- a/src/test/java/io/gravitee/resource/ai_model/client/InferenceServiceClientInferTest.java
+++ b/src/test/java/io/gravitee/resource/ai_model/client/InferenceServiceClientInferTest.java
@@ -20,15 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.inference.api.classifier.ClassifierResult;
 import io.gravitee.inference.api.classifier.ClassifierResults;
 import io.gravitee.resource.ai_model.api.ModelInvokeException;
-import io.gravitee.resource.ai_model.api.model.ModelFileType;
 import io.gravitee.resource.ai_model.api.model.PromptInput;
+import io.reactivex.rxjava3.core.Completable;
+import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.rxjava3.core.Vertx;
@@ -45,16 +44,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class InferenceServiceClientTest {
+class InferenceServiceClientInferTest {
 
     @Mock
     Vertx vertx;
 
     @Mock
     EventBus eventBus;
-
-    @Mock
-    Message<Buffer> startModelResponse;
 
     @Mock
     Message<Buffer> inferResponse;
@@ -122,14 +118,6 @@ class InferenceServiceClientTest {
         // given
         String existingModelAddress = "cached::model::addr";
         String prompt = "Skip loading?";
-        String classifierJson =
-            """
-            {
-              "results": [
-                { "label": "neutral", "score": 1.0 }
-              ]
-            }
-            """;
 
         Field field = client.getClass().getSuperclass().getDeclaredField("modelAddress");
         field.setAccessible(true);

--- a/src/test/java/io/gravitee/resource/ai_model/client/InferenceServiceClientLoadModelTest.java
+++ b/src/test/java/io/gravitee/resource/ai_model/client/InferenceServiceClientLoadModelTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.resource.ai_model.client;
+
+import static io.gravitee.inference.api.Constants.SERVICE_INFERENCE_MODELS_ADDRESS;
+
+import io.micrometer.common.lang.NonNull;
+import io.reactivex.rxjava3.disposables.Disposable;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.rxjava3.RxHelper;
+import io.vertx.rxjava3.core.Vertx;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InferenceServiceClientLoadModelTest {
+
+    public static final String SOME_ADDESS = "some::addess";
+
+    TextClassificationInferenceClient client;
+
+    Vertx vertx;
+
+    @NonNull
+    Disposable consumer;
+
+    @BeforeEach
+    void setup() {
+        this.vertx = Vertx.vertx();
+        client = new TextClassificationInferenceClient(vertx);
+        consumer =
+            this.vertx.eventBus()
+                .consumer(SERVICE_INFERENCE_MODELS_ADDRESS)
+                .toObservable()
+                .subscribeOn(RxHelper.blockingScheduler(vertx.getDelegate()))
+                .observeOn(RxHelper.blockingScheduler(vertx.getDelegate()))
+                .subscribe(message -> {
+                    Thread.sleep(10000);
+                    message.reply(Buffer.buffer(SOME_ADDESS));
+                });
+    }
+
+    @Test
+    void must_load_model_with_latency() {
+        client
+            .loadModel(Map.of("some", "configuration"))
+            .test()
+            .awaitDone(20, TimeUnit.SECONDS)
+            .assertComplete()
+            .assertNoErrors()
+            .assertValue(SOME_ADDESS::equals);
+    }
+
+    @AfterEach
+    public void teardown() {
+        consumer.dispose();
+    }
+}


### PR DESCRIPTION
**Description**

This PR validates load model on blocking scheduler
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0-chore-tests-on-blocking-load-model-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-text-classification/1.0.0-chore-tests-on-blocking-load-model-SNAPSHOT/gravitee-resource-ai-model-text-classification-1.0.0-chore-tests-on-blocking-load-model-SNAPSHOT.zip)
  <!-- Version placeholder end -->
