### PR TITLE
chore(deps): bump gravitee-parent to 23.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>23.2.1</version>
+        <version>23.3.0</version>
     </parent>
 
     <groupId>io.gravitee.resource</groupId>
@@ -219,37 +219,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <properties>
-                        <owner>The Gravitee team</owner>
-                        <email>http://gravitee.io</email>
-                    </properties>
-                    <licenseSets>
-                        <licenseSet>
-                            <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
-                            <excludes>
-                                <exclude>NOTICE.txt</exclude>
-                                <exclude>LICENSE.txt</exclude>
-                                <exclude>**/README</exclude>
-                                <exclude>src/main/packaging/**</exclude>
-                                <exclude>src/test/resources/**</exclude>
-                                <exclude>src/main/resources/**</exclude>
-                                <exclude>src/main/webapp/**</exclude>
-                                <exclude>node_modules/**</exclude>
-                                <exclude>dist/**</exclude>
-                                <exclude>.tmp/**</exclude>
-                                <exclude>.*</exclude>
-                                <exclude>.*/**</exclude>
-                                <exclude>**/*.adoc</exclude>
-                            </excludes>
-                        </licenseSet>
-                    </licenseSets>
-                    <skip>${skip.validation}</skip>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-XXXX

**Description**

A small description of what you did in that PR.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.0.0`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-text-classification/1.0.0/gravitee-resource-ai-model-text-classification-1.0.0.zip)
  <!-- Version placeholder end -->
