### PR TITLE
feat: add new bert tiny/mini/small toxicity models

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,6 +40,11 @@ The AI model text classification resource provides the following models:
 - link:https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-22M-onnx[gravitee-io/Llama-Prompt-Guard-2-22M-onnx]
 - link:https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-86M-onnx[gravitee-io/Llama-Prompt-Guard-2-86M-onnx]
 
+In addition to the models above, we've added 3 new lightweight models:
+- link:https://huggingface.co/gravitee-io/bert-tiny-toxicity[gravitee-io/bert-tiny-toxicity]
+- link:https://huggingface.co/gravitee-io/bert-mini-toxicity[gravitee-io/bert-mini-toxcity]
+- link:https://huggingface.co/gravitee-io/bert-small-toxicity[gravitee-io/bert-small-toxcity]
+
 NOTE: The models are not included in the resource package. The resource automatically downloads the models from Hugging Face when they are not available locally. The Models files are stored in `$GRAVITEE_HOME/models` directory. Ensure that the user that runs the Gateway can write in that directory.
 
 WARNING: Models are loaded in memory. You may need to increase the memory (Java Heap size and Kubernetes resource limits) of the Gateway to avoid any OutOfMemory error. The increase depends on the model size and the number of APIs that use the resource.

--- a/src/main/java/io/gravitee/resource/ai_model/configuration/ModelEnum.java
+++ b/src/main/java/io/gravitee/resource/ai_model/configuration/ModelEnum.java
@@ -41,6 +41,28 @@ public enum ModelEnum {
         "tokenizer.json",
         "config.json"
     ),
+    GRAVITEE_IO_BERT_TINY_TOXICITY(
+        "GRAVITEE_IO_BERT_TINY_TOXICITY",
+        "gravitee-io/bert-tiny-toxicity",
+        "model.quant.onnx",
+        "tokenizer.json",
+        "config.json"
+    ),
+    GRAVITEE_IO_BERT_MINI_TOXICITY(
+        "GRAVITEE_IO_BERT_MINI_TOXICITY",
+        "gravitee-io/bert-mini-toxicity",
+        "model.quant.onnx",
+        "tokenizer.json",
+        "config.json"
+    ),
+    GRAVITEE_IO_BERT_SMALL_TOXICITY(
+        "GRAVITEE_IO_BERT_SMALL_TOXICITY",
+        "gravitee-io/bert-small-toxicity",
+        "model.quant.onnx",
+        "tokenizer.json",
+        "config.json"
+    ),
+
     GRAVITEE_LLAMA_PROMPT_GUARD_22M_MODEL(
         "GRAVITEE_LLAMA_PROMPT_GUARD_22M_MODEL",
         "gravitee-io/Llama-Prompt-Guard-2-22M-onnx",

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -34,6 +34,33 @@
                     "required": ["type"]
                 },
                 {
+                    "title": "gravitee-io/bert-tiny-toxicity",
+                    "properties": {
+                        "type": {
+                            "const": "GRAVITEE_IO_BERT_TINY_TOXICITY"
+                        }
+                    },
+                    "required": ["type"]
+                },
+                {
+                    "title": "gravitee-io/bert-mini-toxicity",
+                    "properties": {
+                        "type": {
+                            "const": "GRAVITEE_IO_BERT_MINI_TOXICITY"
+                        }
+                    },
+                    "required": ["type"]
+                },
+                {
+                    "title": "gravitee-io/bert-small-toxicity",
+                    "properties": {
+                        "type": {
+                            "const": "GRAVITEE_IO_BERT_SMALL_TOXICITY"
+                        }
+                    },
+                    "required": ["type"]
+                },
+                {
                     "title": "gravitee-io/Llama-Prompt-Guard-2-22M-onnx",
                     "properties": {
                         "type": {


### PR DESCRIPTION
**Description**

This PR aims to add 3 new models:
- https://huggingface.co/gravitee-io/bert-tiny-toxicity
- https://huggingface.co/gravitee-io/bert-mini-toxicity
- https://huggingface.co/gravitee-io/bert-small-toxicity

Which are lightweights models compared to their counterparts

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-feat-add-new-lightweight-models-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-text-classification/2.1.0-feat-add-new-lightweight-models-SNAPSHOT/gravitee-resource-ai-model-text-classification-2.1.0-feat-add-new-lightweight-models-SNAPSHOT.zip)
  <!-- Version placeholder end -->
