### PR TITLE
feat: bump gravitee-resource-ai-model-api to 2.2.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -17,8 +17,8 @@ The resource is used to fetch and invoke a text classification model for Gravite
 |===
 | AI Model Text Classification Resource plugin | APIM
 
-| 1.x
-| 4.8.x
+| 1.x | 4.8.x
+| 2.x | 4.9.x
 |===
 
 == Notice
@@ -41,6 +41,7 @@ The AI model text classification resource provides the following models:
 - link:https://huggingface.co/gravitee-io/Llama-Prompt-Guard-2-86M-onnx[gravitee-io/Llama-Prompt-Guard-2-86M-onnx]
 
 In addition to the models above, we've added 3 new lightweight models:
+
 - link:https://huggingface.co/gravitee-io/bert-tiny-toxicity[gravitee-io/bert-tiny-toxicity]
 - link:https://huggingface.co/gravitee-io/bert-mini-toxicity[gravitee-io/bert-mini-toxcity]
 - link:https://huggingface.co/gravitee-io/bert-small-toxicity[gravitee-io/bert-small-toxcity]

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <gravitee-common.version>4.7.0</gravitee-common.version>
         <gravitee-node.version>7.10.0</gravitee-node.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-ai-model-api.version>2.1.0</gravitee-resource-ai-model-api.version>
-        <gravitee-inference-service.version>1.2.0</gravitee-inference-service.version>
+        <gravitee-resource-ai-model-api.version>2.2.0-fix-typos-SNAPSHOT</gravitee-resource-ai-model-api.version>
+        <gravitee-inference-service.version>1.3.2</gravitee-inference-service.version>
         <wiremock.version>3.13.1</wiremock.version>
 
         <maven-plugin-properties.version>1.2.1</maven-plugin-properties.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-common.version>4.7.0</gravitee-common.version>
         <gravitee-node.version>7.10.0</gravitee-node.version>
         <gravitee-resource-api.version>1.1.0</gravitee-resource-api.version>
-        <gravitee-resource-ai-model-api.version>2.2.0-fix-typos-SNAPSHOT</gravitee-resource-ai-model-api.version>
+        <gravitee-resource-ai-model-api.version>2.2.0</gravitee-resource-ai-model-api.version>
         <gravitee-inference-service.version>1.3.2</gravitee-inference-service.version>
         <wiremock.version>3.13.1</wiremock.version>
 


### PR DESCRIPTION
This PR bumps the `gravitee-resource-ai-model-api` to 2.2.0 to match with the inference service
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.2.0-feat-bump-inference-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/resource/gravitee-resource-ai-model-text-classification/2.2.0-feat-bump-inference-api-SNAPSHOT/gravitee-resource-ai-model-text-classification-2.2.0-feat-bump-inference-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
